### PR TITLE
Removed app icon refs from manifest

### DIFF
--- a/android/capacitor-youtube-player/src/main/AndroidManifest.xml
+++ b/android/capacitor-youtube-player/src/main/AndroidManifest.xml
@@ -4,9 +4,7 @@
 
   <application
       android:allowBackup="true"
-      android:icon="@mipmap/ic_launcher"
       android:label="@string/app_name"
-      android:roundIcon="@mipmap/ic_launcher_round"
       android:supportsRtl="true"
       android:theme="@style/AppTheme">
     <activity android:name="com.abpjap.plugin.youtubeplayer.YoutubePlayerFragment">


### PR DESCRIPTION
Addresses the android release build issue - #18 

The solution was to remove `mipmap/ic_launcher` and `ic_launcher_round` references in the android manifest.