### PR TITLE
Removed the activity and intent filter from manifest

### DIFF
--- a/android/capacitor-youtube-player/src/main/AndroidManifest.xml
+++ b/android/capacitor-youtube-player/src/main/AndroidManifest.xml
@@ -7,13 +7,6 @@
       android:label="@string/app_name"
       android:supportsRtl="true"
       android:theme="@style/AppTheme">
-    <activity android:name="com.abpjap.plugin.youtubeplayer.YoutubePlayerFragment">
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-    </activity>
   </application>
 
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
Solves issue #21 

Removed the intent filter and the activity from the manifest. This will make sure that there are no duplicate app launchers when an android project uses the plugin.